### PR TITLE
Make npm module public

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,5 @@
   "license": "Apache-2.0",
   "dependencies": {
     "es6-promise": "^2.3.0"
-  },
-  "publishConfig": {
-    "registry": "http://npm.internal.magnet.me:4873/"
   }
 }


### PR DESCRIPTION
We use this in at least one other open source project (mm-experiments),
which can't be build if this isn't in the public npm registry. The repo
is already open source, so this doesn't expose anything that wasn't
exposed already.

There isn't much to review, so I'll just merge it.